### PR TITLE
Icon centered for dark/light toggle

### DIFF
--- a/src/lib/shared/ui/components/navigation-bar/NavigationBar.svelte
+++ b/src/lib/shared/ui/components/navigation-bar/NavigationBar.svelte
@@ -77,7 +77,7 @@
 			type="button"
 			class="{useTitleAndLogo
 				? 'sticky-theme-mode-button w-8 h-8 bg-yellow-50 rounded-full dark:bg-gray-800 filter shadow hover:shadow-md dark:shadow-dark dark:hover:shadow-dark-lg hover:border-2 hover:border-gray-500 dark:hover:border-gray-300 z-10'
-				: 'w-8 h-8 bg-yellow-50 rounded-full dark:bg-gray-800 filter shadow hover:shadow-md dark:shadow-dark dark:hover:shadow-dark-lg hover:border-2 hover:border-gray-500 dark:hover:border-gray-300 z-10'}"
+				: 'w-8 h-8 bg-yellow-50 rounded-full dark:bg-gray-800 filter shadow hover:shadow-md dark:shadow-dark dark:hover:shadow-dark-lg hover:border-2 hover:border-gray-500 dark:hover:border-gray-300 z-10 flex justify-center items-center'}"
 		>
 			{#if dark}
 				<Icon data="{faSun}" class="{'h-3 w-3 text-xs text-gray-700 dark:text-gray-100'}" scale="{1.5}" />


### PR DESCRIPTION
The dark mode toggle button's icon is centered. 

### Before
![image](https://github.com/navneetsharmaui/sveltekit-blog/assets/42182303/d7704ab2-f451-48e3-b87d-5915ad130d2d)


### After
![image](https://github.com/navneetsharmaui/sveltekit-blog/assets/42182303/092b0a45-f55b-4d00-972b-f43cbc8149b6)
